### PR TITLE
fix(Infos.vue): ajout d'espaces insécables avant deux-points

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -5,19 +5,19 @@
     <hr />
     <div v-if="info.resume" class="resume">
       <section v-if="info.resume.preparationTime">
-        <p>Temps de préparation :</p>
+        <p>Temps de préparation&nbsp;:</p>
         <h3>{{ info.resume.preparationTime }} minutes</h3>
       </section>
       <section v-if="info.resume.cookingTime">
-        <p>Temps de cuisson :</p>
+        <p>Temps de cuisson&nbsp;:</p>
         <h3>{{ info.resume.cookingTime }} minutes</h3>
       </section>
       <section v-if="info.resume.difficulty">
-        <p>Difficulté :</p>
+        <p>Difficulté&nbsp;:</p>
         <h3>{{ info.resume.difficulty }}</h3>
       </section>
       <section v-if="info.resume.cost">
-        <p>Cout :</p>
+        <p>Cout&nbsp;:</p>
         <h3>{{ info.resume.cost }}</h3>
       </section>
     </div>
@@ -26,11 +26,11 @@
     </div>
     <div class="list">
       <div v-if="info.ingredients">
-        <h3>Ingrédients :</h3>
+        <h3>Ingrédients&nbsp;:</h3>
         <Liste :listData="info.ingredients" class="list-ul" type="ingredient" />
       </div>
       <div v-if="info.tools">
-        <h3>Ustensiles :</h3>
+        <h3>Ustensiles&nbsp;:</h3>
         <Liste :listData="info.tools" class="list-ul" type="ustencile" />
       </div>
     </div>

--- a/components/Infos.vue
+++ b/components/Infos.vue
@@ -4,10 +4,10 @@
       Temps total :
       {{ infoObject.preparationTime + infoObject.cookingTime }} minutes
     </li>
-    <li>Temps de préparation : {{ infoObject.preparationTime }} minutes</li>
-    <li>Temps de cuisson : {{ infoObject.cookingTime }} minutes</li>
-    <li>Difficulté : {{ infoObject.difficulty }}</li>
-    <li>Prix : {{ infoObject.price }}</li>
+    <li>Temps de préparation&nbsp;: {{ infoObject.preparationTime }} minutes</li>
+    <li>Temps de cuisson&nbsp;: {{ infoObject.cookingTime }} minutes</li>
+    <li>Difficulté&nbsp;: {{ infoObject.difficulty }}</li>
+    <li>Prix&nbsp;: {{ infoObject.price }}</li>
   </ul>
 </template>
 


### PR DESCRIPTION
Ajout d'espaces insécables pour éviter les retours à la ligne avant les espaces:

Avant
![image](https://user-images.githubusercontent.com/31325038/117070216-ba8f0200-ad2d-11eb-85d6-f454539f7555.png)
Après
![image](https://user-images.githubusercontent.com/31325038/117070249-c4b10080-ad2d-11eb-8bf8-10e009ff88c8.png)

